### PR TITLE
Extra useful defines for H7 family

### DIFF
--- a/Include/stm32h723xx.h
+++ b/Include/stm32h723xx.h
@@ -678,6 +678,20 @@ typedef struct
   __IO uint32_t  CMDR;      /*!< MDMA channel x Mask Data register,                    Address offset: 0x74 */
 }MDMA_Channel_TypeDef;
 
+typedef struct
+{
+  __IO uint32_t  CTCR;      /*!< Loaded into CTCR when linked list in CLAR is followed */
+  __IO uint32_t  CBNDTR;    /*!< Loaded into CBNDTR when linked list in CLAR is followed */
+  __IO uint32_t  CSAR;      /*!< Loaded into CSAR when linked list in CLAR is followed */
+  __IO uint32_t  CDAR;      /*!< Loaded into CDAR when linked list in CLAR is followed */
+  __IO uint32_t  CBRUR;     /*!< Loaded into CBRUR when linked list in CLAR is followed */
+  __IO uint32_t  CLAR;      /*!< Loaded into CLAR to set up the next link, or 0 to terminate the list */
+  __IO uint32_t  CTBR;      /*!< Loaded into CTBR when linked list in CLAR is followed */
+  uint32_t       RESERVED0;
+  __IO uint32_t  CMAR;      /*!< Loaded into CMAR when linked list in CLAR is followed */
+  __IO uint32_t  CMDR;      /*!< Loaded into CMDR when linked list in CLAR is followed */
+}MDMA_LinkNode_TypeDef;
+
 /**
   * @brief DMA2D Controller
   */
@@ -2594,6 +2608,7 @@ typedef struct
 #define DMA2_Stream5        ((DMA_Stream_TypeDef *) DMA2_Stream5_BASE)
 #define DMA2_Stream6        ((DMA_Stream_TypeDef *) DMA2_Stream6_BASE)
 #define DMA2_Stream7        ((DMA_Stream_TypeDef *) DMA2_Stream7_BASE)
+#define DMA2_Stream(N)      ((DMA_Stream_TypeDef *)(DMA2_Stream0_BASE + ((N) * (DMA2_Stream1_BASE - DMA2_Stream0_BASE))))
 
 #define DMA1                ((DMA_TypeDef *) DMA1_BASE)
 #define DMA1_Stream0        ((DMA_Stream_TypeDef *) DMA1_Stream0_BASE)
@@ -2604,7 +2619,7 @@ typedef struct
 #define DMA1_Stream5        ((DMA_Stream_TypeDef *) DMA1_Stream5_BASE)
 #define DMA1_Stream6        ((DMA_Stream_TypeDef *) DMA1_Stream6_BASE)
 #define DMA1_Stream7        ((DMA_Stream_TypeDef *) DMA1_Stream7_BASE)
-
+#define DMA1_Stream(N)      ((DMA_Stream_TypeDef *)(DMA1_Stream0_BASE + ((N) * (DMA1_Stream1_BASE - DMA1_Stream0_BASE))))
 
 #define DMAMUX1              ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
 #define DMAMUX1_Channel0     ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
@@ -2681,7 +2696,7 @@ typedef struct
 #define MDMA_Channel13      ((MDMA_Channel_TypeDef *)MDMA_Channel13_BASE)
 #define MDMA_Channel14      ((MDMA_Channel_TypeDef *)MDMA_Channel14_BASE)
 #define MDMA_Channel15      ((MDMA_Channel_TypeDef *)MDMA_Channel15_BASE)
-
+#define MDMA_Channel(N)     ((MDMA_Channel_TypeDef *)(MDMA_Channel0_BASE + ((N) * (MDMA_Channel1_BASE - MDMA_Channel0_BASE))))
 
 #define USB1_OTG_HS         ((USB_OTG_GlobalTypeDef *) USB1_OTG_HS_PERIPH_BASE)
 
@@ -13222,6 +13237,9 @@ typedef struct
 #define IWDG_KR_KEY_Pos      (0U)
 #define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
 #define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+#define IWDG_KR_KEY_ACCESS   (0x5555UL << IWDG_KR_KEY_Pos)                     /*!<Value to write to access PR, WINR, RLR */
+#define IWDG_KR_KEY_SERVICE  (0xAAAAUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to service IWDG */
+#define IWDG_KR_KEY_START    (0xCCCCUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to start IWDG */
 
 /*******************  Bit definition for IWDG_PR register  ********************/
 #define IWDG_PR_PR_Pos       (0U)

--- a/Include/stm32h725xx.h
+++ b/Include/stm32h725xx.h
@@ -679,6 +679,20 @@ typedef struct
   __IO uint32_t  CMDR;      /*!< MDMA channel x Mask Data register,                    Address offset: 0x74 */
 }MDMA_Channel_TypeDef;
 
+typedef struct
+{
+  __IO uint32_t  CTCR;      /*!< Loaded into CTCR when linked list in CLAR is followed */
+  __IO uint32_t  CBNDTR;    /*!< Loaded into CBNDTR when linked list in CLAR is followed */
+  __IO uint32_t  CSAR;      /*!< Loaded into CSAR when linked list in CLAR is followed */
+  __IO uint32_t  CDAR;      /*!< Loaded into CDAR when linked list in CLAR is followed */
+  __IO uint32_t  CBRUR;     /*!< Loaded into CBRUR when linked list in CLAR is followed */
+  __IO uint32_t  CLAR;      /*!< Loaded into CLAR to set up the next link, or 0 to terminate the list */
+  __IO uint32_t  CTBR;      /*!< Loaded into CTBR when linked list in CLAR is followed */
+  uint32_t       RESERVED0;
+  __IO uint32_t  CMAR;      /*!< Loaded into CMAR when linked list in CLAR is followed */
+  __IO uint32_t  CMDR;      /*!< Loaded into CMDR when linked list in CLAR is followed */
+}MDMA_LinkNode_TypeDef;
+
 /**
   * @brief DMA2D Controller
   */
@@ -2595,6 +2609,7 @@ typedef struct
 #define DMA2_Stream5        ((DMA_Stream_TypeDef *) DMA2_Stream5_BASE)
 #define DMA2_Stream6        ((DMA_Stream_TypeDef *) DMA2_Stream6_BASE)
 #define DMA2_Stream7        ((DMA_Stream_TypeDef *) DMA2_Stream7_BASE)
+#define DMA2_Stream(N)      ((DMA_Stream_TypeDef *)(DMA2_Stream0_BASE + ((N) * (DMA2_Stream1_BASE - DMA2_Stream0_BASE))))
 
 #define DMA1                ((DMA_TypeDef *) DMA1_BASE)
 #define DMA1_Stream0        ((DMA_Stream_TypeDef *) DMA1_Stream0_BASE)
@@ -2605,7 +2620,7 @@ typedef struct
 #define DMA1_Stream5        ((DMA_Stream_TypeDef *) DMA1_Stream5_BASE)
 #define DMA1_Stream6        ((DMA_Stream_TypeDef *) DMA1_Stream6_BASE)
 #define DMA1_Stream7        ((DMA_Stream_TypeDef *) DMA1_Stream7_BASE)
-
+#define DMA1_Stream(N)      ((DMA_Stream_TypeDef *)(DMA1_Stream0_BASE + ((N) * (DMA1_Stream1_BASE - DMA1_Stream0_BASE))))
 
 #define DMAMUX1              ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
 #define DMAMUX1_Channel0     ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
@@ -2682,7 +2697,7 @@ typedef struct
 #define MDMA_Channel13      ((MDMA_Channel_TypeDef *)MDMA_Channel13_BASE)
 #define MDMA_Channel14      ((MDMA_Channel_TypeDef *)MDMA_Channel14_BASE)
 #define MDMA_Channel15      ((MDMA_Channel_TypeDef *)MDMA_Channel15_BASE)
-
+#define MDMA_Channel(N)     ((MDMA_Channel_TypeDef *)(MDMA_Channel0_BASE + ((N) * (MDMA_Channel1_BASE - MDMA_Channel0_BASE))))
 
 #define USB1_OTG_HS         ((USB_OTG_GlobalTypeDef *) USB1_OTG_HS_PERIPH_BASE)
 
@@ -13223,6 +13238,9 @@ typedef struct
 #define IWDG_KR_KEY_Pos      (0U)
 #define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
 #define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+#define IWDG_KR_KEY_ACCESS   (0x5555UL << IWDG_KR_KEY_Pos)                     /*!<Value to write to access PR, WINR, RLR */
+#define IWDG_KR_KEY_SERVICE  (0xAAAAUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to service IWDG */
+#define IWDG_KR_KEY_START    (0xCCCCUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to start IWDG */
 
 /*******************  Bit definition for IWDG_PR register  ********************/
 #define IWDG_PR_PR_Pos       (0U)

--- a/Include/stm32h730xx.h
+++ b/Include/stm32h730xx.h
@@ -681,6 +681,20 @@ typedef struct
   __IO uint32_t  CMDR;      /*!< MDMA channel x Mask Data register,                    Address offset: 0x74 */
 }MDMA_Channel_TypeDef;
 
+typedef struct
+{
+  __IO uint32_t  CTCR;      /*!< Loaded into CTCR when linked list in CLAR is followed */
+  __IO uint32_t  CBNDTR;    /*!< Loaded into CBNDTR when linked list in CLAR is followed */
+  __IO uint32_t  CSAR;      /*!< Loaded into CSAR when linked list in CLAR is followed */
+  __IO uint32_t  CDAR;      /*!< Loaded into CDAR when linked list in CLAR is followed */
+  __IO uint32_t  CBRUR;     /*!< Loaded into CBRUR when linked list in CLAR is followed */
+  __IO uint32_t  CLAR;      /*!< Loaded into CLAR to set up the next link, or 0 to terminate the list */
+  __IO uint32_t  CTBR;      /*!< Loaded into CTBR when linked list in CLAR is followed */
+  uint32_t       RESERVED0;
+  __IO uint32_t  CMAR;      /*!< Loaded into CMAR when linked list in CLAR is followed */
+  __IO uint32_t  CMDR;      /*!< Loaded into CMDR when linked list in CLAR is followed */
+}MDMA_LinkNode_TypeDef;
+
 /**
   * @brief DMA2D Controller
   */
@@ -2717,6 +2731,7 @@ typedef struct
 #define DMA2_Stream5        ((DMA_Stream_TypeDef *) DMA2_Stream5_BASE)
 #define DMA2_Stream6        ((DMA_Stream_TypeDef *) DMA2_Stream6_BASE)
 #define DMA2_Stream7        ((DMA_Stream_TypeDef *) DMA2_Stream7_BASE)
+#define DMA2_Stream(N)      ((DMA_Stream_TypeDef *)(DMA2_Stream0_BASE + ((N) * (DMA2_Stream1_BASE - DMA2_Stream0_BASE))))
 
 #define DMA1                ((DMA_TypeDef *) DMA1_BASE)
 #define DMA1_Stream0        ((DMA_Stream_TypeDef *) DMA1_Stream0_BASE)
@@ -2727,7 +2742,7 @@ typedef struct
 #define DMA1_Stream5        ((DMA_Stream_TypeDef *) DMA1_Stream5_BASE)
 #define DMA1_Stream6        ((DMA_Stream_TypeDef *) DMA1_Stream6_BASE)
 #define DMA1_Stream7        ((DMA_Stream_TypeDef *) DMA1_Stream7_BASE)
-
+#define DMA1_Stream(N)      ((DMA_Stream_TypeDef *)(DMA1_Stream0_BASE + ((N) * (DMA1_Stream1_BASE - DMA1_Stream0_BASE))))
 
 #define DMAMUX1              ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
 #define DMAMUX1_Channel0     ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
@@ -2816,7 +2831,7 @@ typedef struct
 #define MDMA_Channel13      ((MDMA_Channel_TypeDef *)MDMA_Channel13_BASE)
 #define MDMA_Channel14      ((MDMA_Channel_TypeDef *)MDMA_Channel14_BASE)
 #define MDMA_Channel15      ((MDMA_Channel_TypeDef *)MDMA_Channel15_BASE)
-
+#define MDMA_Channel(N)     ((MDMA_Channel_TypeDef *)(MDMA_Channel0_BASE + ((N) * (MDMA_Channel1_BASE - MDMA_Channel0_BASE))))
 
 #define USB1_OTG_HS         ((USB_OTG_GlobalTypeDef *) USB1_OTG_HS_PERIPH_BASE)
 
@@ -13552,6 +13567,9 @@ typedef struct
 #define IWDG_KR_KEY_Pos      (0U)
 #define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
 #define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+#define IWDG_KR_KEY_ACCESS   (0x5555UL << IWDG_KR_KEY_Pos)                     /*!<Value to write to access PR, WINR, RLR */
+#define IWDG_KR_KEY_SERVICE  (0xAAAAUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to service IWDG */
+#define IWDG_KR_KEY_START    (0xCCCCUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to start IWDG */
 
 /*******************  Bit definition for IWDG_PR register  ********************/
 #define IWDG_PR_PR_Pos       (0U)

--- a/Include/stm32h730xxq.h
+++ b/Include/stm32h730xxq.h
@@ -682,6 +682,20 @@ typedef struct
   __IO uint32_t  CMDR;      /*!< MDMA channel x Mask Data register,                    Address offset: 0x74 */
 }MDMA_Channel_TypeDef;
 
+typedef struct
+{
+  __IO uint32_t  CTCR;      /*!< Loaded into CTCR when linked list in CLAR is followed */
+  __IO uint32_t  CBNDTR;    /*!< Loaded into CBNDTR when linked list in CLAR is followed */
+  __IO uint32_t  CSAR;      /*!< Loaded into CSAR when linked list in CLAR is followed */
+  __IO uint32_t  CDAR;      /*!< Loaded into CDAR when linked list in CLAR is followed */
+  __IO uint32_t  CBRUR;     /*!< Loaded into CBRUR when linked list in CLAR is followed */
+  __IO uint32_t  CLAR;      /*!< Loaded into CLAR to set up the next link, or 0 to terminate the list */
+  __IO uint32_t  CTBR;      /*!< Loaded into CTBR when linked list in CLAR is followed */
+  uint32_t       RESERVED0;
+  __IO uint32_t  CMAR;      /*!< Loaded into CMAR when linked list in CLAR is followed */
+  __IO uint32_t  CMDR;      /*!< Loaded into CMDR when linked list in CLAR is followed */
+}MDMA_LinkNode_TypeDef;
+
 /**
   * @brief DMA2D Controller
   */
@@ -2718,6 +2732,7 @@ typedef struct
 #define DMA2_Stream5        ((DMA_Stream_TypeDef *) DMA2_Stream5_BASE)
 #define DMA2_Stream6        ((DMA_Stream_TypeDef *) DMA2_Stream6_BASE)
 #define DMA2_Stream7        ((DMA_Stream_TypeDef *) DMA2_Stream7_BASE)
+#define DMA2_Stream(N)      ((DMA_Stream_TypeDef *)(DMA2_Stream0_BASE + ((N) * (DMA2_Stream1_BASE - DMA2_Stream0_BASE))))
 
 #define DMA1                ((DMA_TypeDef *) DMA1_BASE)
 #define DMA1_Stream0        ((DMA_Stream_TypeDef *) DMA1_Stream0_BASE)
@@ -2728,7 +2743,7 @@ typedef struct
 #define DMA1_Stream5        ((DMA_Stream_TypeDef *) DMA1_Stream5_BASE)
 #define DMA1_Stream6        ((DMA_Stream_TypeDef *) DMA1_Stream6_BASE)
 #define DMA1_Stream7        ((DMA_Stream_TypeDef *) DMA1_Stream7_BASE)
-
+#define DMA1_Stream(N)      ((DMA_Stream_TypeDef *)(DMA1_Stream0_BASE + ((N) * (DMA1_Stream1_BASE - DMA1_Stream0_BASE))))
 
 #define DMAMUX1              ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
 #define DMAMUX1_Channel0     ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
@@ -2817,7 +2832,7 @@ typedef struct
 #define MDMA_Channel13      ((MDMA_Channel_TypeDef *)MDMA_Channel13_BASE)
 #define MDMA_Channel14      ((MDMA_Channel_TypeDef *)MDMA_Channel14_BASE)
 #define MDMA_Channel15      ((MDMA_Channel_TypeDef *)MDMA_Channel15_BASE)
-
+#define MDMA_Channel(N)     ((MDMA_Channel_TypeDef *)(MDMA_Channel0_BASE + ((N) * (MDMA_Channel1_BASE - MDMA_Channel0_BASE))))
 
 #define USB1_OTG_HS         ((USB_OTG_GlobalTypeDef *) USB1_OTG_HS_PERIPH_BASE)
 
@@ -13553,6 +13568,9 @@ typedef struct
 #define IWDG_KR_KEY_Pos      (0U)
 #define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
 #define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+#define IWDG_KR_KEY_ACCESS   (0x5555UL << IWDG_KR_KEY_Pos)                     /*!<Value to write to access PR, WINR, RLR */
+#define IWDG_KR_KEY_SERVICE  (0xAAAAUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to service IWDG */
+#define IWDG_KR_KEY_START    (0xCCCCUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to start IWDG */
 
 /*******************  Bit definition for IWDG_PR register  ********************/
 #define IWDG_PR_PR_Pos       (0U)

--- a/Include/stm32h733xx.h
+++ b/Include/stm32h733xx.h
@@ -681,6 +681,20 @@ typedef struct
   __IO uint32_t  CMDR;      /*!< MDMA channel x Mask Data register,                    Address offset: 0x74 */
 }MDMA_Channel_TypeDef;
 
+typedef struct
+{
+  __IO uint32_t  CTCR;      /*!< Loaded into CTCR when linked list in CLAR is followed */
+  __IO uint32_t  CBNDTR;    /*!< Loaded into CBNDTR when linked list in CLAR is followed */
+  __IO uint32_t  CSAR;      /*!< Loaded into CSAR when linked list in CLAR is followed */
+  __IO uint32_t  CDAR;      /*!< Loaded into CDAR when linked list in CLAR is followed */
+  __IO uint32_t  CBRUR;     /*!< Loaded into CBRUR when linked list in CLAR is followed */
+  __IO uint32_t  CLAR;      /*!< Loaded into CLAR to set up the next link, or 0 to terminate the list */
+  __IO uint32_t  CTBR;      /*!< Loaded into CTBR when linked list in CLAR is followed */
+  uint32_t       RESERVED0;
+  __IO uint32_t  CMAR;      /*!< Loaded into CMAR when linked list in CLAR is followed */
+  __IO uint32_t  CMDR;      /*!< Loaded into CMDR when linked list in CLAR is followed */
+}MDMA_LinkNode_TypeDef;
+
 /**
   * @brief DMA2D Controller
   */
@@ -2717,6 +2731,7 @@ typedef struct
 #define DMA2_Stream5        ((DMA_Stream_TypeDef *) DMA2_Stream5_BASE)
 #define DMA2_Stream6        ((DMA_Stream_TypeDef *) DMA2_Stream6_BASE)
 #define DMA2_Stream7        ((DMA_Stream_TypeDef *) DMA2_Stream7_BASE)
+#define DMA2_Stream(N)      ((DMA_Stream_TypeDef *)(DMA2_Stream0_BASE + ((N) * (DMA2_Stream1_BASE - DMA2_Stream0_BASE))))
 
 #define DMA1                ((DMA_TypeDef *) DMA1_BASE)
 #define DMA1_Stream0        ((DMA_Stream_TypeDef *) DMA1_Stream0_BASE)
@@ -2727,7 +2742,7 @@ typedef struct
 #define DMA1_Stream5        ((DMA_Stream_TypeDef *) DMA1_Stream5_BASE)
 #define DMA1_Stream6        ((DMA_Stream_TypeDef *) DMA1_Stream6_BASE)
 #define DMA1_Stream7        ((DMA_Stream_TypeDef *) DMA1_Stream7_BASE)
-
+#define DMA1_Stream(N)      ((DMA_Stream_TypeDef *)(DMA1_Stream0_BASE + ((N) * (DMA1_Stream1_BASE - DMA1_Stream0_BASE))))
 
 #define DMAMUX1              ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
 #define DMAMUX1_Channel0     ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
@@ -2816,7 +2831,7 @@ typedef struct
 #define MDMA_Channel13      ((MDMA_Channel_TypeDef *)MDMA_Channel13_BASE)
 #define MDMA_Channel14      ((MDMA_Channel_TypeDef *)MDMA_Channel14_BASE)
 #define MDMA_Channel15      ((MDMA_Channel_TypeDef *)MDMA_Channel15_BASE)
-
+#define MDMA_Channel(N)     ((MDMA_Channel_TypeDef *)(MDMA_Channel0_BASE + ((N) * (MDMA_Channel1_BASE - MDMA_Channel0_BASE))))
 
 #define USB1_OTG_HS         ((USB_OTG_GlobalTypeDef *) USB1_OTG_HS_PERIPH_BASE)
 
@@ -13552,6 +13567,9 @@ typedef struct
 #define IWDG_KR_KEY_Pos      (0U)
 #define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
 #define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+#define IWDG_KR_KEY_ACCESS   (0x5555UL << IWDG_KR_KEY_Pos)                     /*!<Value to write to access PR, WINR, RLR */
+#define IWDG_KR_KEY_SERVICE  (0xAAAAUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to service IWDG */
+#define IWDG_KR_KEY_START    (0xCCCCUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to start IWDG */
 
 /*******************  Bit definition for IWDG_PR register  ********************/
 #define IWDG_PR_PR_Pos       (0U)

--- a/Include/stm32h735xx.h
+++ b/Include/stm32h735xx.h
@@ -682,6 +682,20 @@ typedef struct
   __IO uint32_t  CMDR;      /*!< MDMA channel x Mask Data register,                    Address offset: 0x74 */
 }MDMA_Channel_TypeDef;
 
+typedef struct
+{
+  __IO uint32_t  CTCR;      /*!< Loaded into CTCR when linked list in CLAR is followed */
+  __IO uint32_t  CBNDTR;    /*!< Loaded into CBNDTR when linked list in CLAR is followed */
+  __IO uint32_t  CSAR;      /*!< Loaded into CSAR when linked list in CLAR is followed */
+  __IO uint32_t  CDAR;      /*!< Loaded into CDAR when linked list in CLAR is followed */
+  __IO uint32_t  CBRUR;     /*!< Loaded into CBRUR when linked list in CLAR is followed */
+  __IO uint32_t  CLAR;      /*!< Loaded into CLAR to set up the next link, or 0 to terminate the list */
+  __IO uint32_t  CTBR;      /*!< Loaded into CTBR when linked list in CLAR is followed */
+  uint32_t       RESERVED0;
+  __IO uint32_t  CMAR;      /*!< Loaded into CMAR when linked list in CLAR is followed */
+  __IO uint32_t  CMDR;      /*!< Loaded into CMDR when linked list in CLAR is followed */
+}MDMA_LinkNode_TypeDef;
+
 /**
   * @brief DMA2D Controller
   */
@@ -2718,6 +2732,7 @@ typedef struct
 #define DMA2_Stream5        ((DMA_Stream_TypeDef *) DMA2_Stream5_BASE)
 #define DMA2_Stream6        ((DMA_Stream_TypeDef *) DMA2_Stream6_BASE)
 #define DMA2_Stream7        ((DMA_Stream_TypeDef *) DMA2_Stream7_BASE)
+#define DMA2_Stream(N)      ((DMA_Stream_TypeDef *)(DMA2_Stream0_BASE + ((N) * (DMA2_Stream1_BASE - DMA2_Stream0_BASE))))
 
 #define DMA1                ((DMA_TypeDef *) DMA1_BASE)
 #define DMA1_Stream0        ((DMA_Stream_TypeDef *) DMA1_Stream0_BASE)
@@ -2728,7 +2743,7 @@ typedef struct
 #define DMA1_Stream5        ((DMA_Stream_TypeDef *) DMA1_Stream5_BASE)
 #define DMA1_Stream6        ((DMA_Stream_TypeDef *) DMA1_Stream6_BASE)
 #define DMA1_Stream7        ((DMA_Stream_TypeDef *) DMA1_Stream7_BASE)
-
+#define DMA1_Stream(N)      ((DMA_Stream_TypeDef *)(DMA1_Stream0_BASE + ((N) * (DMA1_Stream1_BASE - DMA1_Stream0_BASE))))
 
 #define DMAMUX1              ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
 #define DMAMUX1_Channel0     ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
@@ -2817,7 +2832,7 @@ typedef struct
 #define MDMA_Channel13      ((MDMA_Channel_TypeDef *)MDMA_Channel13_BASE)
 #define MDMA_Channel14      ((MDMA_Channel_TypeDef *)MDMA_Channel14_BASE)
 #define MDMA_Channel15      ((MDMA_Channel_TypeDef *)MDMA_Channel15_BASE)
-
+#define MDMA_Channel(N)     ((MDMA_Channel_TypeDef *)(MDMA_Channel0_BASE + ((N) * (MDMA_Channel1_BASE - MDMA_Channel0_BASE))))
 
 #define USB1_OTG_HS         ((USB_OTG_GlobalTypeDef *) USB1_OTG_HS_PERIPH_BASE)
 
@@ -13553,6 +13568,9 @@ typedef struct
 #define IWDG_KR_KEY_Pos      (0U)
 #define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
 #define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+#define IWDG_KR_KEY_ACCESS   (0x5555UL << IWDG_KR_KEY_Pos)                     /*!<Value to write to access PR, WINR, RLR */
+#define IWDG_KR_KEY_SERVICE  (0xAAAAUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to service IWDG */
+#define IWDG_KR_KEY_START    (0xCCCCUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to start IWDG */
 
 /*******************  Bit definition for IWDG_PR register  ********************/
 #define IWDG_PR_PR_Pos       (0U)

--- a/Include/stm32h742xx.h
+++ b/Include/stm32h742xx.h
@@ -635,6 +635,20 @@ typedef struct
   __IO uint32_t  CMDR;      /*!< MDMA channel x Mask Data register,                    Address offset: 0x74 */
 }MDMA_Channel_TypeDef;
 
+typedef struct
+{
+  __IO uint32_t  CTCR;      /*!< Loaded into CTCR when linked list in CLAR is followed */
+  __IO uint32_t  CBNDTR;    /*!< Loaded into CBNDTR when linked list in CLAR is followed */
+  __IO uint32_t  CSAR;      /*!< Loaded into CSAR when linked list in CLAR is followed */
+  __IO uint32_t  CDAR;      /*!< Loaded into CDAR when linked list in CLAR is followed */
+  __IO uint32_t  CBRUR;     /*!< Loaded into CBRUR when linked list in CLAR is followed */
+  __IO uint32_t  CLAR;      /*!< Loaded into CLAR to set up the next link, or 0 to terminate the list */
+  __IO uint32_t  CTBR;      /*!< Loaded into CTBR when linked list in CLAR is followed */
+  uint32_t       RESERVED0;
+  __IO uint32_t  CMAR;      /*!< Loaded into CMAR when linked list in CLAR is followed */
+  __IO uint32_t  CMDR;      /*!< Loaded into CMDR when linked list in CLAR is followed */
+}MDMA_LinkNode_TypeDef;
+
 /**
   * @brief DMA2D Controller
   */
@@ -2515,6 +2529,7 @@ typedef struct
 #define DMA2_Stream5        ((DMA_Stream_TypeDef *) DMA2_Stream5_BASE)
 #define DMA2_Stream6        ((DMA_Stream_TypeDef *) DMA2_Stream6_BASE)
 #define DMA2_Stream7        ((DMA_Stream_TypeDef *) DMA2_Stream7_BASE)
+#define DMA2_Stream(N)      ((DMA_Stream_TypeDef *)(DMA2_Stream0_BASE + ((N) * (DMA2_Stream1_BASE - DMA2_Stream0_BASE))))
 
 #define DMA1                ((DMA_TypeDef *) DMA1_BASE)
 #define DMA1_Stream0        ((DMA_Stream_TypeDef *) DMA1_Stream0_BASE)
@@ -2525,7 +2540,7 @@ typedef struct
 #define DMA1_Stream5        ((DMA_Stream_TypeDef *) DMA1_Stream5_BASE)
 #define DMA1_Stream6        ((DMA_Stream_TypeDef *) DMA1_Stream6_BASE)
 #define DMA1_Stream7        ((DMA_Stream_TypeDef *) DMA1_Stream7_BASE)
-
+#define DMA1_Stream(N)      ((DMA_Stream_TypeDef *)(DMA1_Stream0_BASE + ((N) * (DMA1_Stream1_BASE - DMA1_Stream0_BASE))))
 
 #define DMAMUX1              ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
 #define DMAMUX1_Channel0     ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
@@ -2596,7 +2611,7 @@ typedef struct
 #define MDMA_Channel13      ((MDMA_Channel_TypeDef *)MDMA_Channel13_BASE)
 #define MDMA_Channel14      ((MDMA_Channel_TypeDef *)MDMA_Channel14_BASE)
 #define MDMA_Channel15      ((MDMA_Channel_TypeDef *)MDMA_Channel15_BASE)
-
+#define MDMA_Channel(N)     ((MDMA_Channel_TypeDef *)(MDMA_Channel0_BASE + ((N) * (MDMA_Channel1_BASE - MDMA_Channel0_BASE))))
 
 #define USB1_OTG_HS         ((USB_OTG_GlobalTypeDef *) USB1_OTG_HS_PERIPH_BASE)
 #define USB2_OTG_FS         ((USB_OTG_GlobalTypeDef *) USB2_OTG_FS_PERIPH_BASE)
@@ -12872,6 +12887,9 @@ typedef struct
 #define IWDG_KR_KEY_Pos      (0U)
 #define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
 #define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+#define IWDG_KR_KEY_ACCESS   (0x5555UL << IWDG_KR_KEY_Pos)                     /*!<Value to write to access PR, WINR, RLR */
+#define IWDG_KR_KEY_SERVICE  (0xAAAAUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to service IWDG */
+#define IWDG_KR_KEY_START    (0xCCCCUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to start IWDG */
 
 /*******************  Bit definition for IWDG_PR register  ********************/
 #define IWDG_PR_PR_Pos       (0U)

--- a/Include/stm32h743xx.h
+++ b/Include/stm32h743xx.h
@@ -638,6 +638,20 @@ typedef struct
   __IO uint32_t  CMDR;      /*!< MDMA channel x Mask Data register,                    Address offset: 0x74 */
 }MDMA_Channel_TypeDef;
 
+typedef struct
+{
+  __IO uint32_t  CTCR;      /*!< Loaded into CTCR when linked list in CLAR is followed */
+  __IO uint32_t  CBNDTR;    /*!< Loaded into CBNDTR when linked list in CLAR is followed */
+  __IO uint32_t  CSAR;      /*!< Loaded into CSAR when linked list in CLAR is followed */
+  __IO uint32_t  CDAR;      /*!< Loaded into CDAR when linked list in CLAR is followed */
+  __IO uint32_t  CBRUR;     /*!< Loaded into CBRUR when linked list in CLAR is followed */
+  __IO uint32_t  CLAR;      /*!< Loaded into CLAR to set up the next link, or 0 to terminate the list */
+  __IO uint32_t  CTBR;      /*!< Loaded into CTBR when linked list in CLAR is followed */
+  uint32_t       RESERVED0;
+  __IO uint32_t  CMAR;      /*!< Loaded into CMAR when linked list in CLAR is followed */
+  __IO uint32_t  CMDR;      /*!< Loaded into CMDR when linked list in CLAR is followed */
+}MDMA_LinkNode_TypeDef;
+
 /**
   * @brief DMA2D Controller
   */
@@ -2606,6 +2620,7 @@ typedef struct
 #define DMA2_Stream5        ((DMA_Stream_TypeDef *) DMA2_Stream5_BASE)
 #define DMA2_Stream6        ((DMA_Stream_TypeDef *) DMA2_Stream6_BASE)
 #define DMA2_Stream7        ((DMA_Stream_TypeDef *) DMA2_Stream7_BASE)
+#define DMA2_Stream(N)      ((DMA_Stream_TypeDef *)(DMA2_Stream0_BASE + ((N) * (DMA2_Stream1_BASE - DMA2_Stream0_BASE))))
 
 #define DMA1                ((DMA_TypeDef *) DMA1_BASE)
 #define DMA1_Stream0        ((DMA_Stream_TypeDef *) DMA1_Stream0_BASE)
@@ -2616,7 +2631,7 @@ typedef struct
 #define DMA1_Stream5        ((DMA_Stream_TypeDef *) DMA1_Stream5_BASE)
 #define DMA1_Stream6        ((DMA_Stream_TypeDef *) DMA1_Stream6_BASE)
 #define DMA1_Stream7        ((DMA_Stream_TypeDef *) DMA1_Stream7_BASE)
-
+#define DMA1_Stream(N)      ((DMA_Stream_TypeDef *)(DMA1_Stream0_BASE + ((N) * (DMA1_Stream1_BASE - DMA1_Stream0_BASE))))
 
 #define DMAMUX1              ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
 #define DMAMUX1_Channel0     ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
@@ -2691,7 +2706,7 @@ typedef struct
 #define MDMA_Channel13      ((MDMA_Channel_TypeDef *)MDMA_Channel13_BASE)
 #define MDMA_Channel14      ((MDMA_Channel_TypeDef *)MDMA_Channel14_BASE)
 #define MDMA_Channel15      ((MDMA_Channel_TypeDef *)MDMA_Channel15_BASE)
-
+#define MDMA_Channel(N)     ((MDMA_Channel_TypeDef *)(MDMA_Channel0_BASE + ((N) * (MDMA_Channel1_BASE - MDMA_Channel0_BASE))))
 
 #define USB1_OTG_HS         ((USB_OTG_GlobalTypeDef *) USB1_OTG_HS_PERIPH_BASE)
 #define USB2_OTG_FS         ((USB_OTG_GlobalTypeDef *) USB2_OTG_FS_PERIPH_BASE)
@@ -12967,6 +12982,9 @@ typedef struct
 #define IWDG_KR_KEY_Pos      (0U)
 #define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
 #define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+#define IWDG_KR_KEY_ACCESS   (0x5555UL << IWDG_KR_KEY_Pos)                     /*!<Value to write to access PR, WINR, RLR */
+#define IWDG_KR_KEY_SERVICE  (0xAAAAUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to service IWDG */
+#define IWDG_KR_KEY_START    (0xCCCCUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to start IWDG */
 
 /*******************  Bit definition for IWDG_PR register  ********************/
 #define IWDG_PR_PR_Pos       (0U)

--- a/Include/stm32h745xg.h
+++ b/Include/stm32h745xg.h
@@ -670,6 +670,20 @@ typedef struct
   __IO uint32_t  CMDR;      /*!< MDMA channel x Mask Data register,                    Address offset: 0x74 */
 }MDMA_Channel_TypeDef;
 
+typedef struct
+{
+  __IO uint32_t  CTCR;      /*!< Loaded into CTCR when linked list in CLAR is followed */
+  __IO uint32_t  CBNDTR;    /*!< Loaded into CBNDTR when linked list in CLAR is followed */
+  __IO uint32_t  CSAR;      /*!< Loaded into CSAR when linked list in CLAR is followed */
+  __IO uint32_t  CDAR;      /*!< Loaded into CDAR when linked list in CLAR is followed */
+  __IO uint32_t  CBRUR;     /*!< Loaded into CBRUR when linked list in CLAR is followed */
+  __IO uint32_t  CLAR;      /*!< Loaded into CLAR to set up the next link, or 0 to terminate the list */
+  __IO uint32_t  CTBR;      /*!< Loaded into CTBR when linked list in CLAR is followed */
+  uint32_t       RESERVED0;
+  __IO uint32_t  CMAR;      /*!< Loaded into CMAR when linked list in CLAR is followed */
+  __IO uint32_t  CMDR;      /*!< Loaded into CMDR when linked list in CLAR is followed */
+}MDMA_LinkNode_TypeDef;
+
 /**
   * @brief DMA2D Controller
   */
@@ -2696,6 +2710,7 @@ typedef struct
 #define DMA2_Stream5        ((DMA_Stream_TypeDef *) DMA2_Stream5_BASE)
 #define DMA2_Stream6        ((DMA_Stream_TypeDef *) DMA2_Stream6_BASE)
 #define DMA2_Stream7        ((DMA_Stream_TypeDef *) DMA2_Stream7_BASE)
+#define DMA2_Stream(N)      ((DMA_Stream_TypeDef *)(DMA2_Stream0_BASE + ((N) * (DMA2_Stream1_BASE - DMA2_Stream0_BASE))))
 
 #define DMA1                ((DMA_TypeDef *) DMA1_BASE)
 #define DMA1_Stream0        ((DMA_Stream_TypeDef *) DMA1_Stream0_BASE)
@@ -2706,7 +2721,7 @@ typedef struct
 #define DMA1_Stream5        ((DMA_Stream_TypeDef *) DMA1_Stream5_BASE)
 #define DMA1_Stream6        ((DMA_Stream_TypeDef *) DMA1_Stream6_BASE)
 #define DMA1_Stream7        ((DMA_Stream_TypeDef *) DMA1_Stream7_BASE)
-
+#define DMA1_Stream(N)      ((DMA_Stream_TypeDef *)(DMA1_Stream0_BASE + ((N) * (DMA1_Stream1_BASE - DMA1_Stream0_BASE))))
 
 #define DMAMUX1              ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
 #define DMAMUX1_Channel0     ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
@@ -2785,7 +2800,7 @@ typedef struct
 #define MDMA_Channel13      ((MDMA_Channel_TypeDef *)MDMA_Channel13_BASE)
 #define MDMA_Channel14      ((MDMA_Channel_TypeDef *)MDMA_Channel14_BASE)
 #define MDMA_Channel15      ((MDMA_Channel_TypeDef *)MDMA_Channel15_BASE)
-
+#define MDMA_Channel(N)     ((MDMA_Channel_TypeDef *)(MDMA_Channel0_BASE + ((N) * (MDMA_Channel1_BASE - MDMA_Channel0_BASE))))
 
 #define USB1_OTG_HS         ((USB_OTG_GlobalTypeDef *) USB1_OTG_HS_PERIPH_BASE)
 #define USB2_OTG_FS         ((USB_OTG_GlobalTypeDef *) USB2_OTG_FS_PERIPH_BASE)
@@ -13491,6 +13506,9 @@ typedef struct
 #define IWDG_KR_KEY_Pos      (0U)
 #define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
 #define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+#define IWDG_KR_KEY_ACCESS   (0x5555UL << IWDG_KR_KEY_Pos)                     /*!<Value to write to access PR, WINR, RLR */
+#define IWDG_KR_KEY_SERVICE  (0xAAAAUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to service IWDG */
+#define IWDG_KR_KEY_START    (0xCCCCUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to start IWDG */
 
 /*******************  Bit definition for IWDG_PR register  ********************/
 #define IWDG_PR_PR_Pos       (0U)

--- a/Include/stm32h745xx.h
+++ b/Include/stm32h745xx.h
@@ -670,6 +670,20 @@ typedef struct
   __IO uint32_t  CMDR;      /*!< MDMA channel x Mask Data register,                    Address offset: 0x74 */
 }MDMA_Channel_TypeDef;
 
+typedef struct
+{
+  __IO uint32_t  CTCR;      /*!< Loaded into CTCR when linked list in CLAR is followed */
+  __IO uint32_t  CBNDTR;    /*!< Loaded into CBNDTR when linked list in CLAR is followed */
+  __IO uint32_t  CSAR;      /*!< Loaded into CSAR when linked list in CLAR is followed */
+  __IO uint32_t  CDAR;      /*!< Loaded into CDAR when linked list in CLAR is followed */
+  __IO uint32_t  CBRUR;     /*!< Loaded into CBRUR when linked list in CLAR is followed */
+  __IO uint32_t  CLAR;      /*!< Loaded into CLAR to set up the next link, or 0 to terminate the list */
+  __IO uint32_t  CTBR;      /*!< Loaded into CTBR when linked list in CLAR is followed */
+  uint32_t       RESERVED0;
+  __IO uint32_t  CMAR;      /*!< Loaded into CMAR when linked list in CLAR is followed */
+  __IO uint32_t  CMDR;      /*!< Loaded into CMDR when linked list in CLAR is followed */
+}MDMA_LinkNode_TypeDef;
+
 /**
   * @brief DMA2D Controller
   */
@@ -2696,6 +2710,7 @@ typedef struct
 #define DMA2_Stream5        ((DMA_Stream_TypeDef *) DMA2_Stream5_BASE)
 #define DMA2_Stream6        ((DMA_Stream_TypeDef *) DMA2_Stream6_BASE)
 #define DMA2_Stream7        ((DMA_Stream_TypeDef *) DMA2_Stream7_BASE)
+#define DMA2_Stream(N)      ((DMA_Stream_TypeDef *)(DMA2_Stream0_BASE + ((N) * (DMA2_Stream1_BASE - DMA2_Stream0_BASE))))
 
 #define DMA1                ((DMA_TypeDef *) DMA1_BASE)
 #define DMA1_Stream0        ((DMA_Stream_TypeDef *) DMA1_Stream0_BASE)
@@ -2706,7 +2721,7 @@ typedef struct
 #define DMA1_Stream5        ((DMA_Stream_TypeDef *) DMA1_Stream5_BASE)
 #define DMA1_Stream6        ((DMA_Stream_TypeDef *) DMA1_Stream6_BASE)
 #define DMA1_Stream7        ((DMA_Stream_TypeDef *) DMA1_Stream7_BASE)
-
+#define DMA1_Stream(N)      ((DMA_Stream_TypeDef *)(DMA1_Stream0_BASE + ((N) * (DMA1_Stream1_BASE - DMA1_Stream0_BASE))))
 
 #define DMAMUX1              ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
 #define DMAMUX1_Channel0     ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
@@ -2785,7 +2800,7 @@ typedef struct
 #define MDMA_Channel13      ((MDMA_Channel_TypeDef *)MDMA_Channel13_BASE)
 #define MDMA_Channel14      ((MDMA_Channel_TypeDef *)MDMA_Channel14_BASE)
 #define MDMA_Channel15      ((MDMA_Channel_TypeDef *)MDMA_Channel15_BASE)
-
+#define MDMA_Channel(N)     ((MDMA_Channel_TypeDef *)(MDMA_Channel0_BASE + ((N) * (MDMA_Channel1_BASE - MDMA_Channel0_BASE))))
 
 #define USB1_OTG_HS         ((USB_OTG_GlobalTypeDef *) USB1_OTG_HS_PERIPH_BASE)
 #define USB2_OTG_FS         ((USB_OTG_GlobalTypeDef *) USB2_OTG_FS_PERIPH_BASE)
@@ -13491,6 +13506,9 @@ typedef struct
 #define IWDG_KR_KEY_Pos      (0U)
 #define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
 #define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+#define IWDG_KR_KEY_ACCESS   (0x5555UL << IWDG_KR_KEY_Pos)                     /*!<Value to write to access PR, WINR, RLR */
+#define IWDG_KR_KEY_SERVICE  (0xAAAAUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to service IWDG */
+#define IWDG_KR_KEY_START    (0xCCCCUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to start IWDG */
 
 /*******************  Bit definition for IWDG_PR register  ********************/
 #define IWDG_PR_PR_Pos       (0U)

--- a/Include/stm32h747xg.h
+++ b/Include/stm32h747xg.h
@@ -671,6 +671,20 @@ typedef struct
   __IO uint32_t  CMDR;      /*!< MDMA channel x Mask Data register,                    Address offset: 0x74 */
 }MDMA_Channel_TypeDef;
 
+typedef struct
+{
+  __IO uint32_t  CTCR;      /*!< Loaded into CTCR when linked list in CLAR is followed */
+  __IO uint32_t  CBNDTR;    /*!< Loaded into CBNDTR when linked list in CLAR is followed */
+  __IO uint32_t  CSAR;      /*!< Loaded into CSAR when linked list in CLAR is followed */
+  __IO uint32_t  CDAR;      /*!< Loaded into CDAR when linked list in CLAR is followed */
+  __IO uint32_t  CBRUR;     /*!< Loaded into CBRUR when linked list in CLAR is followed */
+  __IO uint32_t  CLAR;      /*!< Loaded into CLAR to set up the next link, or 0 to terminate the list */
+  __IO uint32_t  CTBR;      /*!< Loaded into CTBR when linked list in CLAR is followed */
+  uint32_t       RESERVED0;
+  __IO uint32_t  CMAR;      /*!< Loaded into CMAR when linked list in CLAR is followed */
+  __IO uint32_t  CMDR;      /*!< Loaded into CMDR when linked list in CLAR is followed */
+}MDMA_LinkNode_TypeDef;
+
 /**
   * @brief DMA2D Controller
   */
@@ -2778,6 +2792,7 @@ typedef struct
 #define DMA2_Stream5        ((DMA_Stream_TypeDef *) DMA2_Stream5_BASE)
 #define DMA2_Stream6        ((DMA_Stream_TypeDef *) DMA2_Stream6_BASE)
 #define DMA2_Stream7        ((DMA_Stream_TypeDef *) DMA2_Stream7_BASE)
+#define DMA2_Stream(N)      ((DMA_Stream_TypeDef *)(DMA2_Stream0_BASE + ((N) * (DMA2_Stream1_BASE - DMA2_Stream0_BASE))))
 
 #define DMA1                ((DMA_TypeDef *) DMA1_BASE)
 #define DMA1_Stream0        ((DMA_Stream_TypeDef *) DMA1_Stream0_BASE)
@@ -2788,7 +2803,7 @@ typedef struct
 #define DMA1_Stream5        ((DMA_Stream_TypeDef *) DMA1_Stream5_BASE)
 #define DMA1_Stream6        ((DMA_Stream_TypeDef *) DMA1_Stream6_BASE)
 #define DMA1_Stream7        ((DMA_Stream_TypeDef *) DMA1_Stream7_BASE)
-
+#define DMA1_Stream(N)      ((DMA_Stream_TypeDef *)(DMA1_Stream0_BASE + ((N) * (DMA1_Stream1_BASE - DMA1_Stream0_BASE))))
 
 #define DMAMUX1              ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
 #define DMAMUX1_Channel0     ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
@@ -2868,7 +2883,7 @@ typedef struct
 #define MDMA_Channel13      ((MDMA_Channel_TypeDef *)MDMA_Channel13_BASE)
 #define MDMA_Channel14      ((MDMA_Channel_TypeDef *)MDMA_Channel14_BASE)
 #define MDMA_Channel15      ((MDMA_Channel_TypeDef *)MDMA_Channel15_BASE)
-
+#define MDMA_Channel(N)     ((MDMA_Channel_TypeDef *)(MDMA_Channel0_BASE + ((N) * (MDMA_Channel1_BASE - MDMA_Channel0_BASE))))
 
 #define USB1_OTG_HS         ((USB_OTG_GlobalTypeDef *) USB1_OTG_HS_PERIPH_BASE)
 #define USB2_OTG_FS         ((USB_OTG_GlobalTypeDef *) USB2_OTG_FS_PERIPH_BASE)
@@ -16648,6 +16663,9 @@ typedef struct
 #define IWDG_KR_KEY_Pos      (0U)
 #define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
 #define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+#define IWDG_KR_KEY_ACCESS   (0x5555UL << IWDG_KR_KEY_Pos)                     /*!<Value to write to access PR, WINR, RLR */
+#define IWDG_KR_KEY_SERVICE  (0xAAAAUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to service IWDG */
+#define IWDG_KR_KEY_START    (0xCCCCUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to start IWDG */
 
 /*******************  Bit definition for IWDG_PR register  ********************/
 #define IWDG_PR_PR_Pos       (0U)

--- a/Include/stm32h747xx.h
+++ b/Include/stm32h747xx.h
@@ -671,6 +671,20 @@ typedef struct
   __IO uint32_t  CMDR;      /*!< MDMA channel x Mask Data register,                    Address offset: 0x74 */
 }MDMA_Channel_TypeDef;
 
+typedef struct
+{
+  __IO uint32_t  CTCR;      /*!< Loaded into CTCR when linked list in CLAR is followed */
+  __IO uint32_t  CBNDTR;    /*!< Loaded into CBNDTR when linked list in CLAR is followed */
+  __IO uint32_t  CSAR;      /*!< Loaded into CSAR when linked list in CLAR is followed */
+  __IO uint32_t  CDAR;      /*!< Loaded into CDAR when linked list in CLAR is followed */
+  __IO uint32_t  CBRUR;     /*!< Loaded into CBRUR when linked list in CLAR is followed */
+  __IO uint32_t  CLAR;      /*!< Loaded into CLAR to set up the next link, or 0 to terminate the list */
+  __IO uint32_t  CTBR;      /*!< Loaded into CTBR when linked list in CLAR is followed */
+  uint32_t       RESERVED0;
+  __IO uint32_t  CMAR;      /*!< Loaded into CMAR when linked list in CLAR is followed */
+  __IO uint32_t  CMDR;      /*!< Loaded into CMDR when linked list in CLAR is followed */
+}MDMA_LinkNode_TypeDef;
+
 /**
   * @brief DMA2D Controller
   */
@@ -2778,6 +2792,7 @@ typedef struct
 #define DMA2_Stream5        ((DMA_Stream_TypeDef *) DMA2_Stream5_BASE)
 #define DMA2_Stream6        ((DMA_Stream_TypeDef *) DMA2_Stream6_BASE)
 #define DMA2_Stream7        ((DMA_Stream_TypeDef *) DMA2_Stream7_BASE)
+#define DMA2_Stream(N)      ((DMA_Stream_TypeDef *)(DMA2_Stream0_BASE + ((N) * (DMA2_Stream1_BASE - DMA2_Stream0_BASE))))
 
 #define DMA1                ((DMA_TypeDef *) DMA1_BASE)
 #define DMA1_Stream0        ((DMA_Stream_TypeDef *) DMA1_Stream0_BASE)
@@ -2788,7 +2803,7 @@ typedef struct
 #define DMA1_Stream5        ((DMA_Stream_TypeDef *) DMA1_Stream5_BASE)
 #define DMA1_Stream6        ((DMA_Stream_TypeDef *) DMA1_Stream6_BASE)
 #define DMA1_Stream7        ((DMA_Stream_TypeDef *) DMA1_Stream7_BASE)
-
+#define DMA1_Stream(N)      ((DMA_Stream_TypeDef *)(DMA1_Stream0_BASE + ((N) * (DMA1_Stream1_BASE - DMA1_Stream0_BASE))))
 
 #define DMAMUX1              ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
 #define DMAMUX1_Channel0     ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
@@ -2868,7 +2883,7 @@ typedef struct
 #define MDMA_Channel13      ((MDMA_Channel_TypeDef *)MDMA_Channel13_BASE)
 #define MDMA_Channel14      ((MDMA_Channel_TypeDef *)MDMA_Channel14_BASE)
 #define MDMA_Channel15      ((MDMA_Channel_TypeDef *)MDMA_Channel15_BASE)
-
+#define MDMA_Channel(N)     ((MDMA_Channel_TypeDef *)(MDMA_Channel0_BASE + ((N) * (MDMA_Channel1_BASE - MDMA_Channel0_BASE))))
 
 #define USB1_OTG_HS         ((USB_OTG_GlobalTypeDef *) USB1_OTG_HS_PERIPH_BASE)
 #define USB2_OTG_FS         ((USB_OTG_GlobalTypeDef *) USB2_OTG_FS_PERIPH_BASE)
@@ -16648,6 +16663,9 @@ typedef struct
 #define IWDG_KR_KEY_Pos      (0U)
 #define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
 #define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+#define IWDG_KR_KEY_ACCESS   (0x5555UL << IWDG_KR_KEY_Pos)                     /*!<Value to write to access PR, WINR, RLR */
+#define IWDG_KR_KEY_SERVICE  (0xAAAAUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to service IWDG */
+#define IWDG_KR_KEY_START    (0xCCCCUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to start IWDG */
 
 /*******************  Bit definition for IWDG_PR register  ********************/
 #define IWDG_PR_PR_Pos       (0U)

--- a/Include/stm32h750xx.h
+++ b/Include/stm32h750xx.h
@@ -639,6 +639,20 @@ typedef struct
   __IO uint32_t  CMDR;      /*!< MDMA channel x Mask Data register,                    Address offset: 0x74 */
 }MDMA_Channel_TypeDef;
 
+typedef struct
+{
+  __IO uint32_t  CTCR;      /*!< Loaded into CTCR when linked list in CLAR is followed */
+  __IO uint32_t  CBNDTR;    /*!< Loaded into CBNDTR when linked list in CLAR is followed */
+  __IO uint32_t  CSAR;      /*!< Loaded into CSAR when linked list in CLAR is followed */
+  __IO uint32_t  CDAR;      /*!< Loaded into CDAR when linked list in CLAR is followed */
+  __IO uint32_t  CBRUR;     /*!< Loaded into CBRUR when linked list in CLAR is followed */
+  __IO uint32_t  CLAR;      /*!< Loaded into CLAR to set up the next link, or 0 to terminate the list */
+  __IO uint32_t  CTBR;      /*!< Loaded into CTBR when linked list in CLAR is followed */
+  uint32_t       RESERVED0;
+  __IO uint32_t  CMAR;      /*!< Loaded into CMAR when linked list in CLAR is followed */
+  __IO uint32_t  CMDR;      /*!< Loaded into CMDR when linked list in CLAR is followed */
+}MDMA_LinkNode_TypeDef;
+
 /**
   * @brief DMA2D Controller
   */
@@ -2682,6 +2696,7 @@ typedef struct
 #define DMA2_Stream5        ((DMA_Stream_TypeDef *) DMA2_Stream5_BASE)
 #define DMA2_Stream6        ((DMA_Stream_TypeDef *) DMA2_Stream6_BASE)
 #define DMA2_Stream7        ((DMA_Stream_TypeDef *) DMA2_Stream7_BASE)
+#define DMA2_Stream(N)      ((DMA_Stream_TypeDef *)(DMA2_Stream0_BASE + ((N) * (DMA2_Stream1_BASE - DMA2_Stream0_BASE))))
 
 #define DMA1                ((DMA_TypeDef *) DMA1_BASE)
 #define DMA1_Stream0        ((DMA_Stream_TypeDef *) DMA1_Stream0_BASE)
@@ -2692,7 +2707,7 @@ typedef struct
 #define DMA1_Stream5        ((DMA_Stream_TypeDef *) DMA1_Stream5_BASE)
 #define DMA1_Stream6        ((DMA_Stream_TypeDef *) DMA1_Stream6_BASE)
 #define DMA1_Stream7        ((DMA_Stream_TypeDef *) DMA1_Stream7_BASE)
-
+#define DMA1_Stream(N)      ((DMA_Stream_TypeDef *)(DMA1_Stream0_BASE + ((N) * (DMA1_Stream1_BASE - DMA1_Stream0_BASE))))
 
 #define DMAMUX1              ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
 #define DMAMUX1_Channel0     ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
@@ -2767,7 +2782,7 @@ typedef struct
 #define MDMA_Channel13      ((MDMA_Channel_TypeDef *)MDMA_Channel13_BASE)
 #define MDMA_Channel14      ((MDMA_Channel_TypeDef *)MDMA_Channel14_BASE)
 #define MDMA_Channel15      ((MDMA_Channel_TypeDef *)MDMA_Channel15_BASE)
-
+#define MDMA_Channel(N)     ((MDMA_Channel_TypeDef *)(MDMA_Channel0_BASE + ((N) * (MDMA_Channel1_BASE - MDMA_Channel0_BASE))))
 
 #define USB1_OTG_HS         ((USB_OTG_GlobalTypeDef *) USB1_OTG_HS_PERIPH_BASE)
 #define USB2_OTG_FS         ((USB_OTG_GlobalTypeDef *) USB2_OTG_FS_PERIPH_BASE)
@@ -13230,6 +13245,9 @@ typedef struct
 #define IWDG_KR_KEY_Pos      (0U)
 #define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
 #define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+#define IWDG_KR_KEY_ACCESS   (0x5555UL << IWDG_KR_KEY_Pos)                     /*!<Value to write to access PR, WINR, RLR */
+#define IWDG_KR_KEY_SERVICE  (0xAAAAUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to service IWDG */
+#define IWDG_KR_KEY_START    (0xCCCCUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to start IWDG */
 
 /*******************  Bit definition for IWDG_PR register  ********************/
 #define IWDG_PR_PR_Pos       (0U)

--- a/Include/stm32h753xx.h
+++ b/Include/stm32h753xx.h
@@ -639,6 +639,20 @@ typedef struct
   __IO uint32_t  CMDR;      /*!< MDMA channel x Mask Data register,                    Address offset: 0x74 */
 }MDMA_Channel_TypeDef;
 
+typedef struct
+{
+  __IO uint32_t  CTCR;      /*!< Loaded into CTCR when linked list in CLAR is followed */
+  __IO uint32_t  CBNDTR;    /*!< Loaded into CBNDTR when linked list in CLAR is followed */
+  __IO uint32_t  CSAR;      /*!< Loaded into CSAR when linked list in CLAR is followed */
+  __IO uint32_t  CDAR;      /*!< Loaded into CDAR when linked list in CLAR is followed */
+  __IO uint32_t  CBRUR;     /*!< Loaded into CBRUR when linked list in CLAR is followed */
+  __IO uint32_t  CLAR;      /*!< Loaded into CLAR to set up the next link, or 0 to terminate the list */
+  __IO uint32_t  CTBR;      /*!< Loaded into CTBR when linked list in CLAR is followed */
+  uint32_t       RESERVED0;
+  __IO uint32_t  CMAR;      /*!< Loaded into CMAR when linked list in CLAR is followed */
+  __IO uint32_t  CMDR;      /*!< Loaded into CMDR when linked list in CLAR is followed */
+}MDMA_LinkNode_TypeDef;
+
 /**
   * @brief DMA2D Controller
   */
@@ -2682,6 +2696,7 @@ typedef struct
 #define DMA2_Stream5        ((DMA_Stream_TypeDef *) DMA2_Stream5_BASE)
 #define DMA2_Stream6        ((DMA_Stream_TypeDef *) DMA2_Stream6_BASE)
 #define DMA2_Stream7        ((DMA_Stream_TypeDef *) DMA2_Stream7_BASE)
+#define DMA2_Stream(N)      ((DMA_Stream_TypeDef *)(DMA2_Stream0_BASE + ((N) * (DMA2_Stream1_BASE - DMA2_Stream0_BASE))))
 
 #define DMA1                ((DMA_TypeDef *) DMA1_BASE)
 #define DMA1_Stream0        ((DMA_Stream_TypeDef *) DMA1_Stream0_BASE)
@@ -2692,7 +2707,7 @@ typedef struct
 #define DMA1_Stream5        ((DMA_Stream_TypeDef *) DMA1_Stream5_BASE)
 #define DMA1_Stream6        ((DMA_Stream_TypeDef *) DMA1_Stream6_BASE)
 #define DMA1_Stream7        ((DMA_Stream_TypeDef *) DMA1_Stream7_BASE)
-
+#define DMA1_Stream(N)      ((DMA_Stream_TypeDef *)(DMA1_Stream0_BASE + ((N) * (DMA1_Stream1_BASE - DMA1_Stream0_BASE))))
 
 #define DMAMUX1              ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
 #define DMAMUX1_Channel0     ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
@@ -2767,7 +2782,7 @@ typedef struct
 #define MDMA_Channel13      ((MDMA_Channel_TypeDef *)MDMA_Channel13_BASE)
 #define MDMA_Channel14      ((MDMA_Channel_TypeDef *)MDMA_Channel14_BASE)
 #define MDMA_Channel15      ((MDMA_Channel_TypeDef *)MDMA_Channel15_BASE)
-
+#define MDMA_Channel(N)     ((MDMA_Channel_TypeDef *)(MDMA_Channel0_BASE + ((N) * (MDMA_Channel1_BASE - MDMA_Channel0_BASE))))
 
 #define USB1_OTG_HS         ((USB_OTG_GlobalTypeDef *) USB1_OTG_HS_PERIPH_BASE)
 #define USB2_OTG_FS         ((USB_OTG_GlobalTypeDef *) USB2_OTG_FS_PERIPH_BASE)
@@ -13236,6 +13251,9 @@ typedef struct
 #define IWDG_KR_KEY_Pos      (0U)
 #define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
 #define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+#define IWDG_KR_KEY_ACCESS   (0x5555UL << IWDG_KR_KEY_Pos)                     /*!<Value to write to access PR, WINR, RLR */
+#define IWDG_KR_KEY_SERVICE  (0xAAAAUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to service IWDG */
+#define IWDG_KR_KEY_START    (0xCCCCUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to start IWDG */
 
 /*******************  Bit definition for IWDG_PR register  ********************/
 #define IWDG_PR_PR_Pos       (0U)

--- a/Include/stm32h755xx.h
+++ b/Include/stm32h755xx.h
@@ -671,6 +671,20 @@ typedef struct
   __IO uint32_t  CMDR;      /*!< MDMA channel x Mask Data register,                    Address offset: 0x74 */
 }MDMA_Channel_TypeDef;
 
+typedef struct
+{
+  __IO uint32_t  CTCR;      /*!< Loaded into CTCR when linked list in CLAR is followed */
+  __IO uint32_t  CBNDTR;    /*!< Loaded into CBNDTR when linked list in CLAR is followed */
+  __IO uint32_t  CSAR;      /*!< Loaded into CSAR when linked list in CLAR is followed */
+  __IO uint32_t  CDAR;      /*!< Loaded into CDAR when linked list in CLAR is followed */
+  __IO uint32_t  CBRUR;     /*!< Loaded into CBRUR when linked list in CLAR is followed */
+  __IO uint32_t  CLAR;      /*!< Loaded into CLAR to set up the next link, or 0 to terminate the list */
+  __IO uint32_t  CTBR;      /*!< Loaded into CTBR when linked list in CLAR is followed */
+  uint32_t       RESERVED0;
+  __IO uint32_t  CMAR;      /*!< Loaded into CMAR when linked list in CLAR is followed */
+  __IO uint32_t  CMDR;      /*!< Loaded into CMDR when linked list in CLAR is followed */
+}MDMA_LinkNode_TypeDef;
+
 /**
   * @brief DMA2D Controller
   */
@@ -2772,6 +2786,7 @@ typedef struct
 #define DMA2_Stream5        ((DMA_Stream_TypeDef *) DMA2_Stream5_BASE)
 #define DMA2_Stream6        ((DMA_Stream_TypeDef *) DMA2_Stream6_BASE)
 #define DMA2_Stream7        ((DMA_Stream_TypeDef *) DMA2_Stream7_BASE)
+#define DMA2_Stream(N)      ((DMA_Stream_TypeDef *)(DMA2_Stream0_BASE + ((N) * (DMA2_Stream1_BASE - DMA2_Stream0_BASE))))
 
 #define DMA1                ((DMA_TypeDef *) DMA1_BASE)
 #define DMA1_Stream0        ((DMA_Stream_TypeDef *) DMA1_Stream0_BASE)
@@ -2782,7 +2797,7 @@ typedef struct
 #define DMA1_Stream5        ((DMA_Stream_TypeDef *) DMA1_Stream5_BASE)
 #define DMA1_Stream6        ((DMA_Stream_TypeDef *) DMA1_Stream6_BASE)
 #define DMA1_Stream7        ((DMA_Stream_TypeDef *) DMA1_Stream7_BASE)
-
+#define DMA1_Stream(N)      ((DMA_Stream_TypeDef *)(DMA1_Stream0_BASE + ((N) * (DMA1_Stream1_BASE - DMA1_Stream0_BASE))))
 
 #define DMAMUX1              ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
 #define DMAMUX1_Channel0     ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
@@ -2861,7 +2876,7 @@ typedef struct
 #define MDMA_Channel13      ((MDMA_Channel_TypeDef *)MDMA_Channel13_BASE)
 #define MDMA_Channel14      ((MDMA_Channel_TypeDef *)MDMA_Channel14_BASE)
 #define MDMA_Channel15      ((MDMA_Channel_TypeDef *)MDMA_Channel15_BASE)
-
+#define MDMA_Channel(N)     ((MDMA_Channel_TypeDef *)(MDMA_Channel0_BASE + ((N) * (MDMA_Channel1_BASE - MDMA_Channel0_BASE))))
 
 #define USB1_OTG_HS         ((USB_OTG_GlobalTypeDef *) USB1_OTG_HS_PERIPH_BASE)
 #define USB2_OTG_FS         ((USB_OTG_GlobalTypeDef *) USB2_OTG_FS_PERIPH_BASE)
@@ -13760,6 +13775,9 @@ typedef struct
 #define IWDG_KR_KEY_Pos      (0U)
 #define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
 #define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+#define IWDG_KR_KEY_ACCESS   (0x5555UL << IWDG_KR_KEY_Pos)                     /*!<Value to write to access PR, WINR, RLR */
+#define IWDG_KR_KEY_SERVICE  (0xAAAAUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to service IWDG */
+#define IWDG_KR_KEY_START    (0xCCCCUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to start IWDG */
 
 /*******************  Bit definition for IWDG_PR register  ********************/
 #define IWDG_PR_PR_Pos       (0U)

--- a/Include/stm32h757xx.h
+++ b/Include/stm32h757xx.h
@@ -672,6 +672,20 @@ typedef struct
   __IO uint32_t  CMDR;      /*!< MDMA channel x Mask Data register,                    Address offset: 0x74 */
 }MDMA_Channel_TypeDef;
 
+typedef struct
+{
+  __IO uint32_t  CTCR;      /*!< Loaded into CTCR when linked list in CLAR is followed */
+  __IO uint32_t  CBNDTR;    /*!< Loaded into CBNDTR when linked list in CLAR is followed */
+  __IO uint32_t  CSAR;      /*!< Loaded into CSAR when linked list in CLAR is followed */
+  __IO uint32_t  CDAR;      /*!< Loaded into CDAR when linked list in CLAR is followed */
+  __IO uint32_t  CBRUR;     /*!< Loaded into CBRUR when linked list in CLAR is followed */
+  __IO uint32_t  CLAR;      /*!< Loaded into CLAR to set up the next link, or 0 to terminate the list */
+  __IO uint32_t  CTBR;      /*!< Loaded into CTBR when linked list in CLAR is followed */
+  uint32_t       RESERVED0;
+  __IO uint32_t  CMAR;      /*!< Loaded into CMAR when linked list in CLAR is followed */
+  __IO uint32_t  CMDR;      /*!< Loaded into CMDR when linked list in CLAR is followed */
+}MDMA_LinkNode_TypeDef;
+
 /**
   * @brief DMA2D Controller
   */
@@ -2854,6 +2868,7 @@ typedef struct
 #define DMA2_Stream5        ((DMA_Stream_TypeDef *) DMA2_Stream5_BASE)
 #define DMA2_Stream6        ((DMA_Stream_TypeDef *) DMA2_Stream6_BASE)
 #define DMA2_Stream7        ((DMA_Stream_TypeDef *) DMA2_Stream7_BASE)
+#define DMA2_Stream(N)      ((DMA_Stream_TypeDef *)(DMA2_Stream0_BASE + ((N) * (DMA2_Stream1_BASE - DMA2_Stream0_BASE))))
 
 #define DMA1                ((DMA_TypeDef *) DMA1_BASE)
 #define DMA1_Stream0        ((DMA_Stream_TypeDef *) DMA1_Stream0_BASE)
@@ -2864,7 +2879,7 @@ typedef struct
 #define DMA1_Stream5        ((DMA_Stream_TypeDef *) DMA1_Stream5_BASE)
 #define DMA1_Stream6        ((DMA_Stream_TypeDef *) DMA1_Stream6_BASE)
 #define DMA1_Stream7        ((DMA_Stream_TypeDef *) DMA1_Stream7_BASE)
-
+#define DMA1_Stream(N)      ((DMA_Stream_TypeDef *)(DMA1_Stream0_BASE + ((N) * (DMA1_Stream1_BASE - DMA1_Stream0_BASE))))
 
 #define DMAMUX1              ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
 #define DMAMUX1_Channel0     ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
@@ -2944,7 +2959,7 @@ typedef struct
 #define MDMA_Channel13      ((MDMA_Channel_TypeDef *)MDMA_Channel13_BASE)
 #define MDMA_Channel14      ((MDMA_Channel_TypeDef *)MDMA_Channel14_BASE)
 #define MDMA_Channel15      ((MDMA_Channel_TypeDef *)MDMA_Channel15_BASE)
-
+#define MDMA_Channel(N)     ((MDMA_Channel_TypeDef *)(MDMA_Channel0_BASE + ((N) * (MDMA_Channel1_BASE - MDMA_Channel0_BASE))))
 
 #define USB1_OTG_HS         ((USB_OTG_GlobalTypeDef *) USB1_OTG_HS_PERIPH_BASE)
 #define USB2_OTG_FS         ((USB_OTG_GlobalTypeDef *) USB2_OTG_FS_PERIPH_BASE)
@@ -16917,6 +16932,9 @@ typedef struct
 #define IWDG_KR_KEY_Pos      (0U)
 #define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
 #define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+#define IWDG_KR_KEY_ACCESS   (0x5555UL << IWDG_KR_KEY_Pos)                     /*!<Value to write to access PR, WINR, RLR */
+#define IWDG_KR_KEY_SERVICE  (0xAAAAUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to service IWDG */
+#define IWDG_KR_KEY_START    (0xCCCCUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to start IWDG */
 
 /*******************  Bit definition for IWDG_PR register  ********************/
 #define IWDG_PR_PR_Pos       (0U)

--- a/Include/stm32h7a3xx.h
+++ b/Include/stm32h7a3xx.h
@@ -655,6 +655,20 @@ typedef struct
   __IO uint32_t  CMDR;      /*!< MDMA channel x Mask Data register,                    Address offset: 0x74 */
 }MDMA_Channel_TypeDef;
 
+typedef struct
+{
+  __IO uint32_t  CTCR;      /*!< Loaded into CTCR when linked list in CLAR is followed */
+  __IO uint32_t  CBNDTR;    /*!< Loaded into CBNDTR when linked list in CLAR is followed */
+  __IO uint32_t  CSAR;      /*!< Loaded into CSAR when linked list in CLAR is followed */
+  __IO uint32_t  CDAR;      /*!< Loaded into CDAR when linked list in CLAR is followed */
+  __IO uint32_t  CBRUR;     /*!< Loaded into CBRUR when linked list in CLAR is followed */
+  __IO uint32_t  CLAR;      /*!< Loaded into CLAR to set up the next link, or 0 to terminate the list */
+  __IO uint32_t  CTBR;      /*!< Loaded into CTBR when linked list in CLAR is followed */
+  uint32_t       RESERVED0;
+  __IO uint32_t  CMAR;      /*!< Loaded into CMAR when linked list in CLAR is followed */
+  __IO uint32_t  CMDR;      /*!< Loaded into CMDR when linked list in CLAR is followed */
+}MDMA_LinkNode_TypeDef;
+
 /**
   * @brief DMA2D Controller
   */
@@ -2287,7 +2301,6 @@ typedef struct
 #define MDMA_Channel13_BASE   (MDMA_BASE + 0x00000380UL)
 #define MDMA_Channel14_BASE   (MDMA_BASE + 0x000003C0UL)
 #define MDMA_Channel15_BASE   (MDMA_BASE + 0x00000400UL)
-#define MDMA_Channel16_BASE   (MDMA_BASE + 0x00000440UL)
 
 /* GFXMMU virtual buffers base address */
 #define GFXMMU_VIRTUAL_BUFFERS_BASE  (0x25000000UL)
@@ -2488,6 +2501,7 @@ typedef struct
 #define DMA2_Stream5        ((DMA_Stream_TypeDef *) DMA2_Stream5_BASE)
 #define DMA2_Stream6        ((DMA_Stream_TypeDef *) DMA2_Stream6_BASE)
 #define DMA2_Stream7        ((DMA_Stream_TypeDef *) DMA2_Stream7_BASE)
+#define DMA2_Stream(N)      ((DMA_Stream_TypeDef *)(DMA2_Stream0_BASE + ((N) * (DMA2_Stream1_BASE - DMA2_Stream0_BASE))))
 
 #define DMA1                ((DMA_TypeDef *) DMA1_BASE)
 #define DMA1_Stream0        ((DMA_Stream_TypeDef *) DMA1_Stream0_BASE)
@@ -2498,7 +2512,7 @@ typedef struct
 #define DMA1_Stream5        ((DMA_Stream_TypeDef *) DMA1_Stream5_BASE)
 #define DMA1_Stream6        ((DMA_Stream_TypeDef *) DMA1_Stream6_BASE)
 #define DMA1_Stream7        ((DMA_Stream_TypeDef *) DMA1_Stream7_BASE)
-
+#define DMA1_Stream(N)      ((DMA_Stream_TypeDef *)(DMA1_Stream0_BASE + ((N) * (DMA1_Stream1_BASE - DMA1_Stream0_BASE))))
 
 #define DMAMUX1              ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
 #define DMAMUX1_Channel0     ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
@@ -2577,7 +2591,7 @@ typedef struct
 #define MDMA_Channel13      ((MDMA_Channel_TypeDef *)MDMA_Channel13_BASE)
 #define MDMA_Channel14      ((MDMA_Channel_TypeDef *)MDMA_Channel14_BASE)
 #define MDMA_Channel15      ((MDMA_Channel_TypeDef *)MDMA_Channel15_BASE)
-
+#define MDMA_Channel(N)     ((MDMA_Channel_TypeDef *)(MDMA_Channel0_BASE + ((N) * (MDMA_Channel1_BASE - MDMA_Channel0_BASE))))
 
 #define USB1_OTG_HS         ((USB_OTG_GlobalTypeDef *) USB1_OTG_HS_PERIPH_BASE)
 
@@ -11070,6 +11084,9 @@ typedef struct
 #define IWDG_KR_KEY_Pos      (0U)
 #define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
 #define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+#define IWDG_KR_KEY_ACCESS   (0x5555UL << IWDG_KR_KEY_Pos)                     /*!<Value to write to access PR, WINR, RLR */
+#define IWDG_KR_KEY_SERVICE  (0xAAAAUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to service IWDG */
+#define IWDG_KR_KEY_START    (0xCCCCUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to start IWDG */
 
 /*******************  Bit definition for IWDG_PR register  ********************/
 #define IWDG_PR_PR_Pos       (0U)

--- a/Include/stm32h7a3xxq.h
+++ b/Include/stm32h7a3xxq.h
@@ -656,6 +656,20 @@ typedef struct
   __IO uint32_t  CMDR;      /*!< MDMA channel x Mask Data register,                    Address offset: 0x74 */
 }MDMA_Channel_TypeDef;
 
+typedef struct
+{
+  __IO uint32_t  CTCR;      /*!< Loaded into CTCR when linked list in CLAR is followed */
+  __IO uint32_t  CBNDTR;    /*!< Loaded into CBNDTR when linked list in CLAR is followed */
+  __IO uint32_t  CSAR;      /*!< Loaded into CSAR when linked list in CLAR is followed */
+  __IO uint32_t  CDAR;      /*!< Loaded into CDAR when linked list in CLAR is followed */
+  __IO uint32_t  CBRUR;     /*!< Loaded into CBRUR when linked list in CLAR is followed */
+  __IO uint32_t  CLAR;      /*!< Loaded into CLAR to set up the next link, or 0 to terminate the list */
+  __IO uint32_t  CTBR;      /*!< Loaded into CTBR when linked list in CLAR is followed */
+  uint32_t       RESERVED0;
+  __IO uint32_t  CMAR;      /*!< Loaded into CMAR when linked list in CLAR is followed */
+  __IO uint32_t  CMDR;      /*!< Loaded into CMDR when linked list in CLAR is followed */
+}MDMA_LinkNode_TypeDef;
+
 /**
   * @brief DMA2D Controller
   */
@@ -2288,7 +2302,6 @@ typedef struct
 #define MDMA_Channel13_BASE   (MDMA_BASE + 0x00000380UL)
 #define MDMA_Channel14_BASE   (MDMA_BASE + 0x000003C0UL)
 #define MDMA_Channel15_BASE   (MDMA_BASE + 0x00000400UL)
-#define MDMA_Channel16_BASE   (MDMA_BASE + 0x00000440UL)
 
 /* GFXMMU virtual buffers base address */
 #define GFXMMU_VIRTUAL_BUFFERS_BASE  (0x25000000UL)
@@ -2489,6 +2502,7 @@ typedef struct
 #define DMA2_Stream5        ((DMA_Stream_TypeDef *) DMA2_Stream5_BASE)
 #define DMA2_Stream6        ((DMA_Stream_TypeDef *) DMA2_Stream6_BASE)
 #define DMA2_Stream7        ((DMA_Stream_TypeDef *) DMA2_Stream7_BASE)
+#define DMA2_Stream(N)      ((DMA_Stream_TypeDef *)(DMA2_Stream0_BASE + ((N) * (DMA2_Stream1_BASE - DMA2_Stream0_BASE))))
 
 #define DMA1                ((DMA_TypeDef *) DMA1_BASE)
 #define DMA1_Stream0        ((DMA_Stream_TypeDef *) DMA1_Stream0_BASE)
@@ -2499,7 +2513,7 @@ typedef struct
 #define DMA1_Stream5        ((DMA_Stream_TypeDef *) DMA1_Stream5_BASE)
 #define DMA1_Stream6        ((DMA_Stream_TypeDef *) DMA1_Stream6_BASE)
 #define DMA1_Stream7        ((DMA_Stream_TypeDef *) DMA1_Stream7_BASE)
-
+#define DMA1_Stream(N)      ((DMA_Stream_TypeDef *)(DMA1_Stream0_BASE + ((N) * (DMA1_Stream1_BASE - DMA1_Stream0_BASE))))
 
 #define DMAMUX1              ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
 #define DMAMUX1_Channel0     ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
@@ -2578,7 +2592,7 @@ typedef struct
 #define MDMA_Channel13      ((MDMA_Channel_TypeDef *)MDMA_Channel13_BASE)
 #define MDMA_Channel14      ((MDMA_Channel_TypeDef *)MDMA_Channel14_BASE)
 #define MDMA_Channel15      ((MDMA_Channel_TypeDef *)MDMA_Channel15_BASE)
-
+#define MDMA_Channel(N)     ((MDMA_Channel_TypeDef *)(MDMA_Channel0_BASE + ((N) * (MDMA_Channel1_BASE - MDMA_Channel0_BASE))))
 
 #define USB1_OTG_HS         ((USB_OTG_GlobalTypeDef *) USB1_OTG_HS_PERIPH_BASE)
 
@@ -11071,6 +11085,9 @@ typedef struct
 #define IWDG_KR_KEY_Pos      (0U)
 #define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
 #define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+#define IWDG_KR_KEY_ACCESS   (0x5555UL << IWDG_KR_KEY_Pos)                     /*!<Value to write to access PR, WINR, RLR */
+#define IWDG_KR_KEY_SERVICE  (0xAAAAUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to service IWDG */
+#define IWDG_KR_KEY_START    (0xCCCCUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to start IWDG */
 
 /*******************  Bit definition for IWDG_PR register  ********************/
 #define IWDG_PR_PR_Pos       (0U)

--- a/Include/stm32h7b0xx.h
+++ b/Include/stm32h7b0xx.h
@@ -658,6 +658,20 @@ typedef struct
   __IO uint32_t  CMDR;      /*!< MDMA channel x Mask Data register,                    Address offset: 0x74 */
 }MDMA_Channel_TypeDef;
 
+typedef struct
+{
+  __IO uint32_t  CTCR;      /*!< Loaded into CTCR when linked list in CLAR is followed */
+  __IO uint32_t  CBNDTR;    /*!< Loaded into CBNDTR when linked list in CLAR is followed */
+  __IO uint32_t  CSAR;      /*!< Loaded into CSAR when linked list in CLAR is followed */
+  __IO uint32_t  CDAR;      /*!< Loaded into CDAR when linked list in CLAR is followed */
+  __IO uint32_t  CBRUR;     /*!< Loaded into CBRUR when linked list in CLAR is followed */
+  __IO uint32_t  CLAR;      /*!< Loaded into CLAR to set up the next link, or 0 to terminate the list */
+  __IO uint32_t  CTBR;      /*!< Loaded into CTBR when linked list in CLAR is followed */
+  uint32_t       RESERVED0;
+  __IO uint32_t  CMAR;      /*!< Loaded into CMAR when linked list in CLAR is followed */
+  __IO uint32_t  CMDR;      /*!< Loaded into CMDR when linked list in CLAR is followed */
+}MDMA_LinkNode_TypeDef;
+
 /**
   * @brief DMA2D Controller
   */
@@ -2407,7 +2421,6 @@ typedef struct
 #define MDMA_Channel13_BASE   (MDMA_BASE + 0x00000380UL)
 #define MDMA_Channel14_BASE   (MDMA_BASE + 0x000003C0UL)
 #define MDMA_Channel15_BASE   (MDMA_BASE + 0x00000400UL)
-#define MDMA_Channel16_BASE   (MDMA_BASE + 0x00000440UL)
 
 /* GFXMMU virtual buffers base address */
 #define GFXMMU_VIRTUAL_BUFFERS_BASE  (0x25000000UL)
@@ -2611,6 +2624,7 @@ typedef struct
 #define DMA2_Stream5        ((DMA_Stream_TypeDef *) DMA2_Stream5_BASE)
 #define DMA2_Stream6        ((DMA_Stream_TypeDef *) DMA2_Stream6_BASE)
 #define DMA2_Stream7        ((DMA_Stream_TypeDef *) DMA2_Stream7_BASE)
+#define DMA2_Stream(N)      ((DMA_Stream_TypeDef *)(DMA2_Stream0_BASE + ((N) * (DMA2_Stream1_BASE - DMA2_Stream0_BASE))))
 
 #define DMA1                ((DMA_TypeDef *) DMA1_BASE)
 #define DMA1_Stream0        ((DMA_Stream_TypeDef *) DMA1_Stream0_BASE)
@@ -2621,7 +2635,7 @@ typedef struct
 #define DMA1_Stream5        ((DMA_Stream_TypeDef *) DMA1_Stream5_BASE)
 #define DMA1_Stream6        ((DMA_Stream_TypeDef *) DMA1_Stream6_BASE)
 #define DMA1_Stream7        ((DMA_Stream_TypeDef *) DMA1_Stream7_BASE)
-
+#define DMA1_Stream(N)      ((DMA_Stream_TypeDef *)(DMA1_Stream0_BASE + ((N) * (DMA1_Stream1_BASE - DMA1_Stream0_BASE))))
 
 #define DMAMUX1              ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
 #define DMAMUX1_Channel0     ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
@@ -2712,7 +2726,7 @@ typedef struct
 #define MDMA_Channel13      ((MDMA_Channel_TypeDef *)MDMA_Channel13_BASE)
 #define MDMA_Channel14      ((MDMA_Channel_TypeDef *)MDMA_Channel14_BASE)
 #define MDMA_Channel15      ((MDMA_Channel_TypeDef *)MDMA_Channel15_BASE)
-
+#define MDMA_Channel(N)     ((MDMA_Channel_TypeDef *)(MDMA_Channel0_BASE + ((N) * (MDMA_Channel1_BASE - MDMA_Channel0_BASE))))
 
 #define USB1_OTG_HS         ((USB_OTG_GlobalTypeDef *) USB1_OTG_HS_PERIPH_BASE)
 
@@ -11393,6 +11407,9 @@ typedef struct
 #define IWDG_KR_KEY_Pos      (0U)
 #define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
 #define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+#define IWDG_KR_KEY_ACCESS   (0x5555UL << IWDG_KR_KEY_Pos)                     /*!<Value to write to access PR, WINR, RLR */
+#define IWDG_KR_KEY_SERVICE  (0xAAAAUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to service IWDG */
+#define IWDG_KR_KEY_START    (0xCCCCUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to start IWDG */
 
 /*******************  Bit definition for IWDG_PR register  ********************/
 #define IWDG_PR_PR_Pos       (0U)

--- a/Include/stm32h7b0xxq.h
+++ b/Include/stm32h7b0xxq.h
@@ -659,6 +659,20 @@ typedef struct
   __IO uint32_t  CMDR;      /*!< MDMA channel x Mask Data register,                    Address offset: 0x74 */
 }MDMA_Channel_TypeDef;
 
+typedef struct
+{
+  __IO uint32_t  CTCR;      /*!< Loaded into CTCR when linked list in CLAR is followed */
+  __IO uint32_t  CBNDTR;    /*!< Loaded into CBNDTR when linked list in CLAR is followed */
+  __IO uint32_t  CSAR;      /*!< Loaded into CSAR when linked list in CLAR is followed */
+  __IO uint32_t  CDAR;      /*!< Loaded into CDAR when linked list in CLAR is followed */
+  __IO uint32_t  CBRUR;     /*!< Loaded into CBRUR when linked list in CLAR is followed */
+  __IO uint32_t  CLAR;      /*!< Loaded into CLAR to set up the next link, or 0 to terminate the list */
+  __IO uint32_t  CTBR;      /*!< Loaded into CTBR when linked list in CLAR is followed */
+  uint32_t       RESERVED0;
+  __IO uint32_t  CMAR;      /*!< Loaded into CMAR when linked list in CLAR is followed */
+  __IO uint32_t  CMDR;      /*!< Loaded into CMDR when linked list in CLAR is followed */
+}MDMA_LinkNode_TypeDef;
+
 /**
   * @brief DMA2D Controller
   */
@@ -2408,7 +2422,6 @@ typedef struct
 #define MDMA_Channel13_BASE   (MDMA_BASE + 0x00000380UL)
 #define MDMA_Channel14_BASE   (MDMA_BASE + 0x000003C0UL)
 #define MDMA_Channel15_BASE   (MDMA_BASE + 0x00000400UL)
-#define MDMA_Channel16_BASE   (MDMA_BASE + 0x00000440UL)
 
 /* GFXMMU virtual buffers base address */
 #define GFXMMU_VIRTUAL_BUFFERS_BASE  (0x25000000UL)
@@ -2612,6 +2625,7 @@ typedef struct
 #define DMA2_Stream5        ((DMA_Stream_TypeDef *) DMA2_Stream5_BASE)
 #define DMA2_Stream6        ((DMA_Stream_TypeDef *) DMA2_Stream6_BASE)
 #define DMA2_Stream7        ((DMA_Stream_TypeDef *) DMA2_Stream7_BASE)
+#define DMA2_Stream(N)      ((DMA_Stream_TypeDef *)(DMA2_Stream0_BASE + ((N) * (DMA2_Stream1_BASE - DMA2_Stream0_BASE))))
 
 #define DMA1                ((DMA_TypeDef *) DMA1_BASE)
 #define DMA1_Stream0        ((DMA_Stream_TypeDef *) DMA1_Stream0_BASE)
@@ -2622,7 +2636,7 @@ typedef struct
 #define DMA1_Stream5        ((DMA_Stream_TypeDef *) DMA1_Stream5_BASE)
 #define DMA1_Stream6        ((DMA_Stream_TypeDef *) DMA1_Stream6_BASE)
 #define DMA1_Stream7        ((DMA_Stream_TypeDef *) DMA1_Stream7_BASE)
-
+#define DMA1_Stream(N)      ((DMA_Stream_TypeDef *)(DMA1_Stream0_BASE + ((N) * (DMA1_Stream1_BASE - DMA1_Stream0_BASE))))
 
 #define DMAMUX1              ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
 #define DMAMUX1_Channel0     ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
@@ -2713,7 +2727,7 @@ typedef struct
 #define MDMA_Channel13      ((MDMA_Channel_TypeDef *)MDMA_Channel13_BASE)
 #define MDMA_Channel14      ((MDMA_Channel_TypeDef *)MDMA_Channel14_BASE)
 #define MDMA_Channel15      ((MDMA_Channel_TypeDef *)MDMA_Channel15_BASE)
-
+#define MDMA_Channel(N)     ((MDMA_Channel_TypeDef *)(MDMA_Channel0_BASE + ((N) * (MDMA_Channel1_BASE - MDMA_Channel0_BASE))))
 
 #define USB1_OTG_HS         ((USB_OTG_GlobalTypeDef *) USB1_OTG_HS_PERIPH_BASE)
 
@@ -11394,6 +11408,9 @@ typedef struct
 #define IWDG_KR_KEY_Pos      (0U)
 #define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
 #define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+#define IWDG_KR_KEY_ACCESS   (0x5555UL << IWDG_KR_KEY_Pos)                     /*!<Value to write to access PR, WINR, RLR */
+#define IWDG_KR_KEY_SERVICE  (0xAAAAUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to service IWDG */
+#define IWDG_KR_KEY_START    (0xCCCCUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to start IWDG */
 
 /*******************  Bit definition for IWDG_PR register  ********************/
 #define IWDG_PR_PR_Pos       (0U)

--- a/Include/stm32h7b3xx.h
+++ b/Include/stm32h7b3xx.h
@@ -658,6 +658,20 @@ typedef struct
   __IO uint32_t  CMDR;      /*!< MDMA channel x Mask Data register,                    Address offset: 0x74 */
 }MDMA_Channel_TypeDef;
 
+typedef struct
+{
+  __IO uint32_t  CTCR;      /*!< Loaded into CTCR when linked list in CLAR is followed */
+  __IO uint32_t  CBNDTR;    /*!< Loaded into CBNDTR when linked list in CLAR is followed */
+  __IO uint32_t  CSAR;      /*!< Loaded into CSAR when linked list in CLAR is followed */
+  __IO uint32_t  CDAR;      /*!< Loaded into CDAR when linked list in CLAR is followed */
+  __IO uint32_t  CBRUR;     /*!< Loaded into CBRUR when linked list in CLAR is followed */
+  __IO uint32_t  CLAR;      /*!< Loaded into CLAR to set up the next link, or 0 to terminate the list */
+  __IO uint32_t  CTBR;      /*!< Loaded into CTBR when linked list in CLAR is followed */
+  uint32_t       RESERVED0;
+  __IO uint32_t  CMAR;      /*!< Loaded into CMAR when linked list in CLAR is followed */
+  __IO uint32_t  CMDR;      /*!< Loaded into CMDR when linked list in CLAR is followed */
+}MDMA_LinkNode_TypeDef;
+
 /**
   * @brief DMA2D Controller
   */
@@ -2407,7 +2421,6 @@ typedef struct
 #define MDMA_Channel13_BASE   (MDMA_BASE + 0x00000380UL)
 #define MDMA_Channel14_BASE   (MDMA_BASE + 0x000003C0UL)
 #define MDMA_Channel15_BASE   (MDMA_BASE + 0x00000400UL)
-#define MDMA_Channel16_BASE   (MDMA_BASE + 0x00000440UL)
 
 /* GFXMMU virtual buffers base address */
 #define GFXMMU_VIRTUAL_BUFFERS_BASE  (0x25000000UL)
@@ -2611,6 +2624,7 @@ typedef struct
 #define DMA2_Stream5        ((DMA_Stream_TypeDef *) DMA2_Stream5_BASE)
 #define DMA2_Stream6        ((DMA_Stream_TypeDef *) DMA2_Stream6_BASE)
 #define DMA2_Stream7        ((DMA_Stream_TypeDef *) DMA2_Stream7_BASE)
+#define DMA2_Stream(N)      ((DMA_Stream_TypeDef *)(DMA2_Stream0_BASE + ((N) * (DMA2_Stream1_BASE - DMA2_Stream0_BASE))))
 
 #define DMA1                ((DMA_TypeDef *) DMA1_BASE)
 #define DMA1_Stream0        ((DMA_Stream_TypeDef *) DMA1_Stream0_BASE)
@@ -2621,7 +2635,7 @@ typedef struct
 #define DMA1_Stream5        ((DMA_Stream_TypeDef *) DMA1_Stream5_BASE)
 #define DMA1_Stream6        ((DMA_Stream_TypeDef *) DMA1_Stream6_BASE)
 #define DMA1_Stream7        ((DMA_Stream_TypeDef *) DMA1_Stream7_BASE)
-
+#define DMA1_Stream(N)      ((DMA_Stream_TypeDef *)(DMA1_Stream0_BASE + ((N) * (DMA1_Stream1_BASE - DMA1_Stream0_BASE))))
 
 #define DMAMUX1              ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
 #define DMAMUX1_Channel0     ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
@@ -2712,7 +2726,7 @@ typedef struct
 #define MDMA_Channel13      ((MDMA_Channel_TypeDef *)MDMA_Channel13_BASE)
 #define MDMA_Channel14      ((MDMA_Channel_TypeDef *)MDMA_Channel14_BASE)
 #define MDMA_Channel15      ((MDMA_Channel_TypeDef *)MDMA_Channel15_BASE)
-
+#define MDMA_Channel(N)     ((MDMA_Channel_TypeDef *)(MDMA_Channel0_BASE + ((N) * (MDMA_Channel1_BASE - MDMA_Channel0_BASE))))
 
 #define USB1_OTG_HS         ((USB_OTG_GlobalTypeDef *) USB1_OTG_HS_PERIPH_BASE)
 
@@ -11400,6 +11414,9 @@ typedef struct
 #define IWDG_KR_KEY_Pos      (0U)
 #define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
 #define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+#define IWDG_KR_KEY_ACCESS   (0x5555UL << IWDG_KR_KEY_Pos)                     /*!<Value to write to access PR, WINR, RLR */
+#define IWDG_KR_KEY_SERVICE  (0xAAAAUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to service IWDG */
+#define IWDG_KR_KEY_START    (0xCCCCUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to start IWDG */
 
 /*******************  Bit definition for IWDG_PR register  ********************/
 #define IWDG_PR_PR_Pos       (0U)

--- a/Include/stm32h7b3xxq.h
+++ b/Include/stm32h7b3xxq.h
@@ -659,6 +659,20 @@ typedef struct
   __IO uint32_t  CMDR;      /*!< MDMA channel x Mask Data register,                    Address offset: 0x74 */
 }MDMA_Channel_TypeDef;
 
+typedef struct
+{
+  __IO uint32_t  CTCR;      /*!< Loaded into CTCR when linked list in CLAR is followed */
+  __IO uint32_t  CBNDTR;    /*!< Loaded into CBNDTR when linked list in CLAR is followed */
+  __IO uint32_t  CSAR;      /*!< Loaded into CSAR when linked list in CLAR is followed */
+  __IO uint32_t  CDAR;      /*!< Loaded into CDAR when linked list in CLAR is followed */
+  __IO uint32_t  CBRUR;     /*!< Loaded into CBRUR when linked list in CLAR is followed */
+  __IO uint32_t  CLAR;      /*!< Loaded into CLAR to set up the next link, or 0 to terminate the list */
+  __IO uint32_t  CTBR;      /*!< Loaded into CTBR when linked list in CLAR is followed */
+  uint32_t       RESERVED0;
+  __IO uint32_t  CMAR;      /*!< Loaded into CMAR when linked list in CLAR is followed */
+  __IO uint32_t  CMDR;      /*!< Loaded into CMDR when linked list in CLAR is followed */
+}MDMA_LinkNode_TypeDef;
+
 /**
   * @brief DMA2D Controller
   */
@@ -2408,7 +2422,6 @@ typedef struct
 #define MDMA_Channel13_BASE   (MDMA_BASE + 0x00000380UL)
 #define MDMA_Channel14_BASE   (MDMA_BASE + 0x000003C0UL)
 #define MDMA_Channel15_BASE   (MDMA_BASE + 0x00000400UL)
-#define MDMA_Channel16_BASE   (MDMA_BASE + 0x00000440UL)
 
 /* GFXMMU virtual buffers base address */
 #define GFXMMU_VIRTUAL_BUFFERS_BASE  (0x25000000UL)
@@ -2612,6 +2625,7 @@ typedef struct
 #define DMA2_Stream5        ((DMA_Stream_TypeDef *) DMA2_Stream5_BASE)
 #define DMA2_Stream6        ((DMA_Stream_TypeDef *) DMA2_Stream6_BASE)
 #define DMA2_Stream7        ((DMA_Stream_TypeDef *) DMA2_Stream7_BASE)
+#define DMA2_Stream(N)      ((DMA_Stream_TypeDef *)(DMA2_Stream0_BASE + ((N) * (DMA2_Stream1_BASE - DMA2_Stream0_BASE))))
 
 #define DMA1                ((DMA_TypeDef *) DMA1_BASE)
 #define DMA1_Stream0        ((DMA_Stream_TypeDef *) DMA1_Stream0_BASE)
@@ -2622,7 +2636,7 @@ typedef struct
 #define DMA1_Stream5        ((DMA_Stream_TypeDef *) DMA1_Stream5_BASE)
 #define DMA1_Stream6        ((DMA_Stream_TypeDef *) DMA1_Stream6_BASE)
 #define DMA1_Stream7        ((DMA_Stream_TypeDef *) DMA1_Stream7_BASE)
-
+#define DMA1_Stream(N)      ((DMA_Stream_TypeDef *)(DMA1_Stream0_BASE + ((N) * (DMA1_Stream1_BASE - DMA1_Stream0_BASE))))
 
 #define DMAMUX1              ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
 #define DMAMUX1_Channel0     ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
@@ -2713,7 +2727,7 @@ typedef struct
 #define MDMA_Channel13      ((MDMA_Channel_TypeDef *)MDMA_Channel13_BASE)
 #define MDMA_Channel14      ((MDMA_Channel_TypeDef *)MDMA_Channel14_BASE)
 #define MDMA_Channel15      ((MDMA_Channel_TypeDef *)MDMA_Channel15_BASE)
-
+#define MDMA_Channel(N)     ((MDMA_Channel_TypeDef *)(MDMA_Channel0_BASE + ((N) * (MDMA_Channel1_BASE - MDMA_Channel0_BASE))))
 
 #define USB1_OTG_HS         ((USB_OTG_GlobalTypeDef *) USB1_OTG_HS_PERIPH_BASE)
 
@@ -11401,6 +11415,9 @@ typedef struct
 #define IWDG_KR_KEY_Pos      (0U)
 #define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
 #define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+#define IWDG_KR_KEY_ACCESS   (0x5555UL << IWDG_KR_KEY_Pos)                     /*!<Value to write to access PR, WINR, RLR */
+#define IWDG_KR_KEY_SERVICE  (0xAAAAUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to service IWDG */
+#define IWDG_KR_KEY_START    (0xCCCCUL << IWDG_KR_KEY_Pos)                     /*!<Value to write to start IWDG */
 
 /*******************  Bit definition for IWDG_PR register  ********************/
 #define IWDG_PR_PR_Pos       (0U)


### PR DESCRIPTION
Applied to all family members:
* Add MDMA_LinkNode_TypeDef which defines the in-memory layout of a linked list node for MDMA
* Add macros for DMA1_Stream, DMA2_Stream, MDMA_Channel to allow the stream or channel to be not hardwired into the define's name
* Add symbolic names for IWDG_KR_KEY values

And only 7b0xx[q]/7a3xx[q]/7b3xx[q]:
* Remove non existent MDMA_Channel16_BASE

## IMPORTANT INFORMATION 

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submiter.
* If you have not signed such agreement, please follow the rules mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/cmsis_device_h7/blob/master/CONTRIBUTING.md) file. 
  


